### PR TITLE
Refactor: BookComment showCharCount 조건 수정

### DIFF
--- a/src/components/BookComment/index.jsx
+++ b/src/components/BookComment/index.jsx
@@ -171,7 +171,7 @@ const BookComment = ({ comments, setModalOpen, setComments, onDeleteComment, pla
                 onChange={(e) => {setEditContent(e.target.value); handleEditCharCount(e);}}
                 className="resize-none w-[500px] whitespace-pre-line focus:outline-none secondary box"
               />
-              {showCharCount && (
+              {showCharCount && editMode === index && (
                 <span className={`absolute bottom-2 right-0 top-12 ${editCharCount > minLength ? 'text-red-500' : ''} text-[10px]`}>
                   {editCharCount}/{minLength}
                 </span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #110 

## 📝작업 내용

>  showCharCount를 props로 사용하지 않는 경우에 {editCharCount}/{minLength} 중에 {editCharCount}/까지만 보이는 이슈 해결 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
