### PR TITLE
Refactor: App, paymentcomplete fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ function App() {
         <Route path="/payment" element={<PaymentPage />} />
         <Route path="/mychallenge" element={<MyChallengePage />} />
         <Route path="/mybookspoiler" element={<MyBookSpoilerPage />} />
-        <Route path="/payment/complete" element={<PaymentComplete />}></Route>
+        <Route path="/payment/complete" element={<PaymentComplete />} />
         <Route path="/myinfo" element={<MyInfoPage />} />
       </Route>
       <Route path="/admin" element={<AdminLayout />}>

--- a/src/pages/Payment/PaymentComplete.jsx
+++ b/src/pages/Payment/PaymentComplete.jsx
@@ -2,8 +2,8 @@ import { Link } from 'react-router-dom';
 
 const PaymentComplete = () => {
   return (
-    <div className="flex justify-center">
-      <div className="pt-[120px] flex text-center flex-col md gap-1 font-bold text-lg">
+    <div className="flex justify-center pt-[150px]">
+      <div className="pt-[120px] pb-[180px] flex text-center flex-col md gap-1 font-bold text-lg">
         <p>결제가 완료되었습니다.</p>
         <p>챌린지 진행 및 결제 내역은</p>
         <p>마이페이지에서 확인 가능합니다.</p>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #136 

## 📝작업 내용

> App paymentcomplete  뒤 라우트  태그 빼기
> paymentcomplete pt, pb 조정으로 페이지가 여유있게 가운데 있도록 수정 (푸터가 콘텐츠 영역까지 다 보이는 것)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)